### PR TITLE
Fix assert! macro usage

### DIFF
--- a/src/qustate.rs
+++ b/src/qustate.rs
@@ -117,7 +117,7 @@ impl QuState
         bits: &[usize])
     where G: crate::gates::Gate + ?Sized
     {
-        assert!(control.len() == self.nr_shots
+        assert!(control.len() == self.nr_shots,
             "The number of control bits does not match the number of runs");
 
         let gate_bits = gate.nr_affected_bits();


### PR DESCRIPTION
There is a bug in rustc that allows adding invalid trailing tokens to
the `assert!` macro call. They are currently ignored but are going to
produce errors in the future.

Fix assert! macro usage to add missing comma.

For more information, see
https://github.com/rust-lang/rust/issues/60024 and
https://github.com/rust-lang/rust/pull/60039